### PR TITLE
feat: improve landing design

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
@@ -10,7 +10,11 @@
     />
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <meta
+      name="description"
+      content="Panadería artesanal en Tres Arroyos, tradición y sabor"
+    />
+    <title>Mio Figlio — Panadería &amp; Pastelería</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -11,7 +11,7 @@ export default function Hero() {
       />
       <div className="absolute inset-0 bg-gradient-to-t from-crema via-crema/10 to-transparent" />
       <div className="max-w-5xl mx-auto px-4 -mt-20 relative">
-        <div className="bg-crema/95 border border-espresso/10 rounded-2xl p-6 md:p-8 shadow-lg">
+        <div className="bg-crema/80 backdrop-blur-md border border-espresso/10 rounded-2xl p-6 md:p-8 shadow-lg animate-fade-in-up">
           <h1 className="font-serif text-3xl md:text-5xl text-espresso">
             Pan artesanal, tradición y sabor
           </h1>

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -1,6 +1,6 @@
 export default function ProductCard({ item }) {
   return (
-    <article className="bg-white rounded-2xl border border-espresso/10 overflow-hidden shadow-sm hover:shadow-md transition">
+    <article className="bg-white rounded-2xl border border-espresso/10 overflow-hidden shadow-sm hover:shadow-lg hover:-translate-y-1 transform transition-transform duration-200">
       <img
         src={item.image}
         alt={item.name}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,15 @@ export default {
       fontFamily: {
         serif: ['"Playfair Display"', "serif"],
         sans: ['Inter', "system-ui", "sans-serif"]
+      },
+      keyframes: {
+        'fade-in-up': {
+          '0%': { opacity: '0', transform: 'translateY(20px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' }
+        }
+      },
+      animation: {
+        'fade-in-up': 'fade-in-up 0.6s ease-out both'
       }
     },
   },


### PR DESCRIPTION
## Summary
- add fade-in animation and blurred card for hero section
- add interactive hover effect to product cards
- update index metadata for spanish bakery brand

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a8723e6588325a2371764d82d4995