### PR TITLE
feat: improve landing design

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
@@ -10,7 +10,11 @@
     />
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <meta
+      name="description"
+      content="Panadería artesanal en Tres Arroyos, tradición y sabor"
+    />
+    <title>Mio Figlio — Panadería &amp; Pastelería</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,6 +1,6 @@
 export default function Hero() {
   return (
-    <section className="relative isolate">
+    <section className="relative isolate pb-16">
       <div
         className="h-[48vh] md:h-[60vh] w-full bg-center bg-cover"
         style={{
@@ -11,7 +11,7 @@ export default function Hero() {
       />
       <div className="absolute inset-0 bg-gradient-to-t from-crema via-crema/10 to-transparent" />
       <div className="max-w-5xl mx-auto px-4 -mt-20 relative">
-        <div className="bg-crema/95 border border-espresso/10 rounded-2xl p-6 md:p-8 shadow-lg">
+        <div className="bg-crema/80 backdrop-blur-md border border-espresso/10 rounded-2xl p-6 md:p-8 shadow-lg animate-fade-in-up">
           <h1 className="font-serif text-3xl md:text-5xl text-espresso">
             Pan artesanal, tradición y sabor
           </h1>

--- a/src/components/MapSection.jsx
+++ b/src/components/MapSection.jsx
@@ -1,7 +1,7 @@
 export default function MapSection() {
   return (
-    <section id="ubicacion" className="bg-white border-t border-espresso/10">
-      <div className="max-w-6xl mx-auto px-4 py-10">
+    <section id="ubicacion" className="border-t border-espresso/10">
+      <div className="max-w-6xl mx-auto px-4 py-16">
         <h2 className="font-serif text-2xl md:text-3xl text-espresso">Dónde estamos</h2>
         <p className="text-carbon/70 mt-1">
           Tres Arroyos, Buenos Aires. Horarios y dirección exacta a confirmar.

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -1,6 +1,6 @@
 export default function ProductCard({ item }) {
   return (
-    <article className="bg-white rounded-2xl border border-espresso/10 overflow-hidden shadow-sm hover:shadow-md transition">
+    <article className="bg-white rounded-2xl border border-espresso/10 overflow-hidden shadow-sm hover:shadow-lg hover:-translate-y-1 transform transition-transform duration-200">
       <img
         src={item.image}
         alt={item.name}

--- a/src/components/ProductsGrid.jsx
+++ b/src/components/ProductsGrid.jsx
@@ -2,8 +2,8 @@ import ProductCard from "./ProductCard";
 
 export default function ProductsGrid({ items, title, subtitle }) {
   return (
-    <section className="max-w-6xl mx-auto px-4 py-10">
-      <header className="mb-6">
+    <section className="max-w-6xl mx-auto px-4 py-16">
+      <header className="mb-8">
         <h2 className="font-serif text-2xl md:text-3xl text-espresso">{title}</h2>
         {subtitle && <p className="text-carbon/70 mt-1">{subtitle}</p>}
       </header>

--- a/src/index.css
+++ b/src/index.css
@@ -8,5 +8,5 @@
 
 html, body, #root {
   height: 100%;
-  background: theme('colors.crema');
+  background: linear-gradient(to bottom, theme('colors.crema'), #f2e9db);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,15 @@ export default {
       fontFamily: {
         serif: ['"Playfair Display"', "serif"],
         sans: ['Inter', "system-ui", "sans-serif"]
+      },
+      keyframes: {
+        'fade-in-up': {
+          '0%': { opacity: '0', transform: 'translateY(20px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' }
+        }
+      },
+      animation: {
+        'fade-in-up': 'fade-in-up 0.6s ease-out both'
       }
     },
   },


### PR DESCRIPTION
## Summary
- add section spacing and bottom padding to hero for better separation
- remove white backgrounds and add subtle page gradient for a polished feel

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a8723e6588325a2371764d82d4995